### PR TITLE
docker build: uprev gosu version to support mac m1 processor

### DIFF
--- a/docker/dmp-ui/Dockerfile
+++ b/docker/dmp-ui/Dockerfile
@@ -29,7 +29,7 @@ RUN cd /usr/local && tar xJf /tmp/node-v16.17.1-linux-x64.tar.xz \
                   && ln -s ../node/bin/npm  npm                 \
                   && ln -s ../node/bin/npx  npx            
 
-ENV GOSU_VERSION 1.10
+ENV GOSU_VERSION 1.14
 RUN set -ex; \
     arch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
     wget -O /usr/local/bin/gosu \


### PR DESCRIPTION
To enable docker-based builds of the dmp tool on modern Macs featuring the m1 processor, it is necessary to use a more recent version of the gosu tool.  

This branch was provided by @Iskander54; PR was created on his behalf.
