### PR TITLE
Enable display of images from assets directory under oar-docker

### DIFF
--- a/oar-dmp/src/app/app.component.ts
+++ b/oar-dmp/src/app/app.component.ts
@@ -13,7 +13,7 @@ export class AppComponent {
   readyDisplay: boolean = false;
   creds: Credentials|null = null;
   authMessage: string = "You are not authenticated.";
-  loginPNG: string = '/../assets/images/checked-user.png'
+  loginPNG: string = 'assets/images/checked-user.png'
   alttext: string="Icon of a user drawing with a check mark to indicated loggedin status"
   
   constructor(private dom:DomPositioningModule,

--- a/oar-dmp/src/app/app.module.ts
+++ b/oar-dmp/src/app/app.module.ts
@@ -82,7 +82,7 @@ import { CONFIG_URL, RELEASE_INFO, AuthModule, FrameModule } from 'oarng';
   ],
 
   providers: [
-   fakeBackendProvider,
+    // fakeBackendProvider,
     // { provide: RELEASE_INFO, useValue: RELEASE },
     // { provide: CONFIG_URL, useValue: environment.configUrl }
   ],

--- a/oar-dmp/src/app/form-components/data-description/data-description.component.ts
+++ b/oar-dmp/src/app/form-components/data-description/data-description.component.ts
@@ -13,7 +13,7 @@ import { DataCategories } from '../../types/data-categories.type';
 })
 export class DataDescriptionComponent implements OnInit {
 
-  pyramid: string = '/../../assets/images/pyramid.png'
+  pyramid: string = 'assets/images/pyramid.png'
   alttext: string="Pyramid View of Data Categories"
 
   availableCategories:DataCategories[]=[


### PR DESCRIPTION
The data pyramid image and the user icon were not being displayed when running under oar-docker.  This PR fixes that issue.  I've tested that this works on the mdsdev server; however, I have not confirmed that it works in standalone development mode.

The key to the fix is to note that the paths to the images are _URL paths_, not filesystem paths.  These paths are interpreted as relative to the URL that the application is downloaded into the browser via<b>**</b>.  The image paths were previously set with a path that starts with `/`, which makes the URL relative to the server, irrespective of the app's URL.  Changing these paths to start with `assets/images` fixes the issue.  

This PR also comments out the use of `fakeBackendProvider` in `app.module.ts` so the branch can be used under oar-docker.  While it is fine to uncomment out this line while in development, it is recommended that we not check that change in; that is, use it only locally.  

-------------
<b>**</b>More specifically, URL paths are interpreted as  relative to the URL specified in the `<base>` element of the `index.html` file in the `src` directory, which is currently set to `/`'  In development mode, this is the URL via which the app is downloaded (in other words, `http://localhost:4041/index.html`.  When served via oar-docker, the proxy server rewrites this element on-the-fly to be `http://host/dmpui/`, which is the URL one downloads the app through which running under oar-docker.  