### PR TITLE
Upgraded the latest integration branch to angular 16

### DIFF
--- a/oar-dmp/angular.json
+++ b/oar-dmp/angular.json
@@ -20,6 +20,15 @@
                 "build": {
                     "builder": "@angular-devkit/build-angular:browser",
                     "options": {
+                        "allowedCommonJsDependencies": [
+                            "raf",
+                            "core-js",
+                            "dompurify",
+                            "html2canvas",
+                            "rgbcolor",
+                            "file-saver",
+                            "lodash"
+                        ],
                         "outputPath": "dist/dmp_ui2",
                         "index": "src/index.html",
                         "main": "src/main.ts",
@@ -48,8 +57,8 @@
                             "budgets": [
                                 {
                                     "type": "initial",
-                                    "maximumWarning": "500kb",
-                                    "maximumError": "1.7mb"
+                                    "maximumWarning": "2mb",
+                                    "maximumError": "1.8mb"
                                 },
                                 {
                                     "type": "anyComponentStyle",
@@ -101,8 +110,7 @@
             }
         }
     },
-    "defaultProject": "dmp_ui2",
     "cli": {
-      "analytics": false
+        "analytics": false
     }
 }

--- a/oar-dmp/package.json
+++ b/oar-dmp/package.json
@@ -12,12 +12,41 @@
   "optionalDependencies": {
     "oarng": "file:../lib/dist/oarng"
   },
+  "dependencies": {
+    "@angular-devkit/build-angular": "^16.2.12",
+    "@angular/animations": "^16.2.12",
+    "@angular/cdk": "^16.2.0",
+    "@angular/common": "^16.2.12",
+    "@angular/compiler": "^16.2.12",
+    "@angular/core": "^16.2.12",
+    "@angular/forms": "^16.2.12",
+    "@angular/material": "^16.2.0",
+    "@angular/platform-browser": "^16.2.12",
+    "@angular/platform-browser-dynamic": "^16.2.12",
+    "@angular/router": "^16.2.12",
+    "@types/file-saver": "^2.0.7",
+    "angular-resize-event": "3.2.0",
+    "file-saver": "^2.0.5",
+    "http-cache-semantics": "^4.1.1",
+    "jspdf": "^2.5.1",
+    "jspdf-autotable": "^3.8.1",
+    "loader-utils": "^3.2.1",
+    "npm": "^8.19.2",
+    "rxjs": "~7.8.1",
+    "socket.io": "^4.6.1",
+    "tslib": "^2.3.0",
+    "zone.js": "~0.13.3"
+  },
   "devDependencies": {
-    "@angular/cli": "^13.3.9",
-    "@angular/compiler-cli": "~13.3.0",
+    "@angular/cli": "^16.2.12",
+    "@angular/compiler-cli": "^16.2.12",
     "@types/jasmine": "~3.10.0",
-    "@types/lodash": "^4.14.180",
+    "@types/lodash": "^4.14.202",
     "@types/node": "^12.11.1",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5",
+    "@types/jest": "^29.5.1",
+    "jest": "^29.5.0",
+    "jest-preset-angular": "13.1.0",
+    "ts-jest": "^29.1.0"
   }
 }

--- a/oar-dmp/src/app/dmp-form/dmp-form.component.ts
+++ b/oar-dmp/src/app/dmp-form/dmp-form.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, ViewChild, AfterViewInit } from '@angular/core';
 import { ObservedValueOf, Subscription } from "rxjs";
-import { FormBuilder, Validators } from '@angular/forms';
+import { UntypedFormBuilder, Validators } from '@angular/forms';
 import { BasicInfoComponent } from '../form-components/basic-info/basic-info.component';
 import { PersonelComponent } from '../form-components/personel/personel.component';
 import { KeywordsComponent } from '../form-components/keywords/keywords.component';
@@ -11,7 +11,7 @@ import { DataPreservationComponent } from '../form-components/data-preservation/
 import { DMP_Meta } from '../types/DMP.types';
 import { DmpService } from '../shared/dmp.service'
 import { SubmitDmpService } from '../shared/submit-dmp.service';//for acknowledging when form button has been 'pressed'
-import { FormControl } from '@angular/forms';
+import { UntypedFormControl } from '@angular/forms';
 
 
 
@@ -104,14 +104,14 @@ export class DmpFormComponent implements OnInit {
 
   markdown:Array<string> = [];
 
-  name = new FormControl('');
+  name = new UntypedFormControl('');
   nameDisabled = false;
   nameClass:string = "mnemonicNameNew";
 
   DMP_PDF?:DmpPdf;
 
   constructor(
-    private fb: FormBuilder, 
+    private fb: UntypedFormBuilder, 
     private dmp_Service: DmpService, 
     private route: ActivatedRoute,
     private router: Router,

--- a/oar-dmp/src/app/form-components/basic-info/basic-info.component.ts
+++ b/oar-dmp/src/app/form-components/basic-info/basic-info.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, Output } from '@angular/core';
-import { FormBuilder, Validators} from '@angular/forms';
+import { UntypedFormBuilder, Validators} from '@angular/forms';
 import { defer, map, of, startWith } from 'rxjs';
 import { DMP_Meta } from '../../types/DMP.types';
 
@@ -78,7 +78,7 @@ export class BasicInfoComponent{
   @Output()
   formReady = of(this.basicInfoForm);
 
-  constructor(private fb: FormBuilder) {
+  constructor(private fb: UntypedFormBuilder) {
     
   }
 

--- a/oar-dmp/src/app/form-components/data-description/data-description.component.ts
+++ b/oar-dmp/src/app/form-components/data-description/data-description.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, Output, OnInit } from '@angular/core';
 //resources service to talk between two components
 import { ResourcesService } from '../../shared/resources.service';
-import { FormArray, FormBuilder, FormControl } from '@angular/forms';
+import { FormArray, UntypedFormBuilder, FormControl } from '@angular/forms';
 import { defer, map, of, startWith } from 'rxjs';
 import { DMP_Meta } from '../../types/DMP.types';
 import { DataCategories } from '../../types/data-categories.type';
@@ -76,7 +76,7 @@ export class DataDescriptionComponent implements OnInit {
     //resources service to talk between two components 
     // (DataDescriptionComponent and ResourceOptionsComponent)
     private sharedService: ResourcesService,
-    private fb: FormBuilder
+    private fb: UntypedFormBuilder
   ) { }
 
   resetCheckboxes(){

--- a/oar-dmp/src/app/form-components/data-preservation/data-preservation.component.ts
+++ b/oar-dmp/src/app/form-components/data-preservation/data-preservation.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, Output } from '@angular/core';
-import { FormBuilder } from '@angular/forms';
+import { UntypedFormBuilder } from '@angular/forms';
 import { defer, map, of, startWith } from 'rxjs';
 import { DMP_Meta } from '../../types/DMP.types';
 
@@ -50,7 +50,7 @@ export class DataPreservationComponent {
     }
   );
 
-  constructor(private fb: FormBuilder) { 
+  constructor(private fb: UntypedFormBuilder) { 
 
   }
 

--- a/oar-dmp/src/app/form-components/ethical-issues/ethical-issues.component.ts
+++ b/oar-dmp/src/app/form-components/ethical-issues/ethical-issues.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, Output, OnInit } from '@angular/core';
-import { FormBuilder, Validators, ControlValueAccessor, NgControl, AbstractControl, FormControl} from '@angular/forms';
+import { UntypedFormBuilder, Validators, ControlValueAccessor, NgControl, AbstractControl, FormControl} from '@angular/forms';
 import { defer, map, of, startWith } from 'rxjs';
 import { DMP_Meta } from '../../types/DMP.types';
 
@@ -66,7 +66,7 @@ export class EthicalIssuesComponent {
   formReady = of(this.ethicalIsuesForm);  
   
 
-  constructor(private fb: FormBuilder) {
+  constructor(private fb: UntypedFormBuilder) {
     
    }
 

--- a/oar-dmp/src/app/form-components/keywords/keywords.component.ts
+++ b/oar-dmp/src/app/form-components/keywords/keywords.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, Output } from '@angular/core';
-import { FormBuilder } from '@angular/forms';
+import { UntypedFormBuilder } from '@angular/forms';
 import { defer, map, of, startWith } from 'rxjs';
 import { DMP_Meta } from '../../types/DMP.types';
 
@@ -48,7 +48,7 @@ export class KeywordsComponent {
     }
   );
 
-  constructor(private fb: FormBuilder) { 
+  constructor(private fb: UntypedFormBuilder) { 
     
   }
 

--- a/oar-dmp/src/app/form-components/personel/personel.component.ts
+++ b/oar-dmp/src/app/form-components/personel/personel.component.ts
@@ -6,7 +6,7 @@ import { DmpAPIService } from '../../shared/dmp-api.service';
 import { DropDownSelectService } from '../../shared/drop-down-select.service';
 import { NistContact } from '../../types/nist-contact'
 
-import { Validators, FormBuilder } from '@angular/forms';
+import { Validators, UntypedFormBuilder } from '@angular/forms';
 import { defer, map, of, startWith } from 'rxjs';
 import { DMP_Meta } from '../../types/DMP.types';
 import { ORGANIZATIONS } from '../../types/mock-organizations';
@@ -180,7 +180,7 @@ export class PersonelComponent implements OnInit {
   constructor(
     private dropDownService: DropDownSelectService,
     private apiService: DmpAPIService,
-    private fb: FormBuilder
+    private fb: UntypedFormBuilder
   ) {
     /**
      * NOTE uncoment this when pulling data from API with a backend database

--- a/oar-dmp/src/app/form-components/technical-requirements/technical-requirements.component.ts
+++ b/oar-dmp/src/app/form-components/technical-requirements/technical-requirements.component.ts
@@ -2,7 +2,7 @@ import { Component, Input, Output } from '@angular/core';
 import { DropDownSelectService } from '../../shared/drop-down-select.service';
 //resources service to talk between two components
 import { ResourcesService } from '../../shared/resources.service';
-import { FormBuilder, Validators } from '@angular/forms';
+import { UntypedFormBuilder, Validators } from '@angular/forms';
 import { defer, map, of, startWith } from 'rxjs';
 // import { DMP_Meta } from 'src/app/types/DMP.types';
 // import { SoftwareDevelopment } from 'src/app/types/software-development.type';
@@ -74,7 +74,7 @@ export class StorageNeedsComponent {
   constructor(
     private dropDownService: DropDownSelectService,
     private sharedService: ResourcesService,
-    private fb: FormBuilder,
+    private fb: UntypedFormBuilder,
   ) { }
 
   // We want to receive the initial data from the parent component and initialize 

--- a/oar-dmp/tsconfig.json
+++ b/oar-dmp/tsconfig.json
@@ -3,7 +3,7 @@
   "compileOnSave": false,
   "compilerOptions": {
     "resolveJsonModule": true,
-    "esModuleInterop":true,
+    "esModuleInterop": true,
     "baseUrl": "./",
     "outDir": "./dist/out-tsc",
     "forceConsistentCasingInFileNames": true,
@@ -18,15 +18,16 @@
     "experimentalDecorators": true,
     "moduleResolution": "node",
     "importHelpers": true,
-    "target": "es2017",
+    "target": "ES2022",
     "module": "es2020",
     "lib": [
       "es2020",
       "dom"
     ],
     "typeRoots": [
-        "node_modules/@types"
-    ]
+      "node_modules/@types"
+    ],
+    "useDefineForClassFields": false
   },
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,

--- a/package.json
+++ b/package.json
@@ -11,35 +11,10 @@
         "start-oardmp": "npm run start dmp_ui2 --prefix ./oar-dmp",
         "test": "jest --config ./oar-dmp/jest.config.js --silent"
     },
-    "dependencies": {
-        "@angular-devkit/build-angular": "^13.3.11",
-        "@angular/animations": "~13.3.0",
-        "@angular/cdk": "^13.3.9",
-        "@angular/common": "~13.3.0",
-        "@angular/compiler": "~13.3.0",
-        "@angular/core": "~13.3.0",
-        "@angular/forms": "~13.3.0",
-        "@angular/material": "^13.3.9",
-        "@angular/platform-browser": "~13.3.0",
-        "@angular/platform-browser-dynamic": "~13.3.0",
-        "@angular/router": "~13.3.0",
-        "@types/file-saver": "^2.0.7",
-        "angular-resize-event": "3.1.1",
-        "file-saver": "^2.0.5",
-        "http-cache-semantics": "^4.1.1",
-        "jspdf": "^2.5.1",
-        "jspdf-autotable": "^3.8.1",
-        "loader-utils": "^3.2.1",
-        "npm": "^8.19.2",
-        "rxjs": "~7.5.0",
-        "socket.io": "^4.6.1",
-        "tslib": "^2.3.0",
-        "zone.js": "~0.11.4"
-    },
     "devDependencies": {
         "@types/jest": "^29.5.1",
         "jest": "^29.5.0",
-        "jest-preset-angular": "^13.0.1",
+        "jest-preset-angular": "13.1.0",
         "ts-jest": "^29.1.0"
     }
 }


### PR DESCRIPTION
Upgraded integration branch to Angular 16.

You need to install node 18.13.0 to run Angular 16.

Use "npm i --legacy-peer-deps" instead of "npm i" to install dependencies because angular-resize-event@3.2.0 requires @angular/common@">= 12.2.0 < 15".

I moved dependencies from root folder to oar-dmp because migration requires dependencies to be inside a project root.


