### PR TITLE
Made all links from DMP GUI open in a new tab

### DIFF
--- a/oar-dmp/src/app/app.component.html
+++ b/oar-dmp/src/app/app.component.html
@@ -7,7 +7,7 @@
                 <div class="dmpHelp">
                     <div class="dmpHelpButton">
                         <span >
-                            <a href="https://inet.nist.gov/mr/library/midas-user-guides/midas-tools/creating-data-management-plans-dmptool" >DMP User Guide</a>
+                            <a href="https://inet.nist.gov/mr/library/midas-user-guides/midas-tools/creating-data-management-plans-dmptool" target="_blank">DMP User Guide</a>
                         </span>
                     </div>
                 </div>

--- a/oar-dmp/src/app/resource-options/resource-options.component.html
+++ b/oar-dmp/src/app/resource-options/resource-options.component.html
@@ -25,7 +25,7 @@
                   'softwareSelection':softwareSelection
                 }
               }">
-                <a href='{{row.link}}'>{{row.text}}</a>
+                <a href='{{row.link}}' target="_blank">{{row.text}}</a>
               </td>
             </tr>
           </table>


### PR DESCRIPTION
Just made a minor change so that links from the DMP interface always open as new tabs.