### PR TITLE
feat: share a DMP from the editor via the permission manager dialog

### DIFF
--- a/oar-dmp/src/app/app.component.html
+++ b/oar-dmp/src/app/app.component.html
@@ -21,7 +21,15 @@
                             Save
                         </button>
                     </div>
-                
+
+                    <div *ngIf="currentDmpId">
+                        <button mat-button type="button" class="btn_draft"
+                                aria-label="Share this record with other users"
+                                (click)="openShareDialog()">
+                            Share
+                        </button>
+                    </div>
+
                     <div>
                         <button mat-button type="button" class="btn_draft"
                                 (click)="dmpButtonClick('Download')"

--- a/oar-dmp/src/app/app.component.spec.ts
+++ b/oar-dmp/src/app/app.component.spec.ts
@@ -1,9 +1,10 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
-import { of, Subject, throwError } from 'rxjs';
+import { of, Subject, BehaviorSubject, throwError } from 'rxjs';
+import { MatDialog } from '@angular/material/dialog';
 
 import { AppComponent } from './app.component';
-import { AuthenticationService, StaffDirectoryService } from 'oarng';
+import { AuthenticationService, StaffDirectoryService, ConfigurationService } from 'oarng';
 import { SubmitDmpService } from './shared/submit-dmp.service';
 import { DropDownSelectService } from './shared/drop-down-select.service';
 import { FormChangedService } from './shared/form-changed.service';
@@ -33,11 +34,16 @@ describe('AppComponent', () => {
 
   let disableSaveBtnSubject: Subject<boolean>;
   let hasUnsavedChangesSubject: Subject<boolean>;
+  let currentDmpIdSubject: BehaviorSubject<string | null>;
 
   let formChangedServiceMock: {
     disableSaveBtn$: Subject<boolean>;
     hasUnsavedChanges$: Subject<boolean>;
+    currentDmpId$: BehaviorSubject<string | null>;
   };
+
+  let dialogMock: { open: jest.Mock };
+  let configServiceMock: { getConfig: jest.Mock };
 
   beforeEach(async () => {
     authServiceMock = {
@@ -61,10 +67,17 @@ describe('AppComponent', () => {
 
     disableSaveBtnSubject = new Subject<boolean>();
     hasUnsavedChangesSubject = new Subject<boolean>();
+    currentDmpIdSubject = new BehaviorSubject<string | null>(null);
 
     formChangedServiceMock = {
       disableSaveBtn$: disableSaveBtnSubject,
-      hasUnsavedChanges$: hasUnsavedChangesSubject
+      hasUnsavedChanges$: hasUnsavedChangesSubject,
+      currentDmpId$: currentDmpIdSubject
+    };
+
+    dialogMock = { open: jest.fn() };
+    configServiceMock = {
+      getConfig: jest.fn().mockReturnValue({ PDRDMP: 'http://localhost:9091/midas/dmp/mdm1' })
     };
 
     authServiceMock.getCredentials.mockReturnValue(
@@ -82,7 +95,9 @@ describe('AppComponent', () => {
         { provide: StaffDirectoryService, useValue: staffDirectoryServiceMock },
         { provide: SubmitDmpService, useValue: submitDmpServiceMock },
         { provide: DropDownSelectService, useValue: dropDownSelectServiceMock },
-        { provide: FormChangedService, useValue: formChangedServiceMock }
+        { provide: FormChangedService, useValue: formChangedServiceMock },
+        { provide: MatDialog, useValue: dialogMock },
+        { provide: ConfigurationService, useValue: configServiceMock }
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
     }).compileComponents();
@@ -254,5 +269,53 @@ describe('AppComponent', () => {
 
     expect(component.disableSaveBtn).toBe(false);
     expect(component.hasUnsavedChanges).toBe(false);
+  });
+
+  describe('currentDmpId and Share dialog', () => {
+    it('should track currentDmpId from FormChangedService', () => {
+      fixture.detectChanges();
+      expect(component.currentDmpId).toBeNull();
+
+      currentDmpIdSubject.next('dmp-abc');
+      expect(component.currentDmpId).toBe('dmp-abc');
+
+      currentDmpIdSubject.next(null);
+      expect(component.currentDmpId).toBeNull();
+    });
+
+    it('should open dialog with correct data when currentDmpId is set', () => {
+      fixture.detectChanges();
+      currentDmpIdSubject.next('dmp-abc');
+
+      component.openShareDialog();
+
+      expect(dialogMock.open).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          data: expect.objectContaining({
+            record: { id: 'dmp-abc', apiBase: 'http://localhost:9091/midas/dmp/mdm1' },
+            title: 'Share my record'
+          }),
+          maxWidth: '95vw'
+        })
+      );
+    });
+
+    it('should not open dialog when currentDmpId is null', () => {
+      fixture.detectChanges();
+      expect(component.currentDmpId).toBeNull();
+
+      component.openShareDialog();
+
+      expect(dialogMock.open).not.toHaveBeenCalled();
+    });
+
+    it('should stop tracking currentDmpId after destroy', () => {
+      fixture.detectChanges();
+      component.ngOnDestroy();
+
+      currentDmpIdSubject.next('dmp-after-destroy');
+      expect(component.currentDmpId).toBeNull();
+    });
   });
 });

--- a/oar-dmp/src/app/app.component.ts
+++ b/oar-dmp/src/app/app.component.ts
@@ -1,9 +1,12 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { Subject, takeUntil } from 'rxjs';
-import { Credentials, AuthenticationService, StaffDirectoryService } from 'oarng';
+import { Credentials, AuthenticationService, StaffDirectoryService, ConfigurationService,
+  PermissionManagerDialogComponent } from 'oarng';
+import { MatDialog } from '@angular/material/dialog';
 import { SubmitDmpService } from './shared/submit-dmp.service';
 import { DropDownSelectService } from './shared/drop-down-select.service';
 import { FormChangedService } from './shared/form-changed.service';
+import { DMPConfiguration } from './shared/config.model';
 
 @Component({
   selector: 'app-root',
@@ -27,6 +30,7 @@ export class AppComponent implements OnInit, OnDestroy {
   disableSaveBtn: boolean = false;
   hasUnsavedChanges: boolean = false;
   disableDownloadBtn: boolean = true;
+  currentDmpId: string | null = null;
 
   private destroy$ = new Subject<void>();
 
@@ -35,7 +39,9 @@ export class AppComponent implements OnInit, OnDestroy {
     private sdsvc: StaffDirectoryService,
     private form_buttons: SubmitDmpService,
     private dropDownService: DropDownSelectService,
-    private formChangedService: FormChangedService
+    private formChangedService: FormChangedService,
+    private dialog: MatDialog,
+    private configService: ConfigurationService
   ) { }
 
   ngOnInit(): void {
@@ -69,6 +75,10 @@ export class AppComponent implements OnInit, OnDestroy {
       });
 
     this.saveButtonSubscribe();
+
+    this.formChangedService.currentDmpId$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(id => { this.currentDmpId = id; });
   }
 
   ngOnDestroy(): void {
@@ -97,6 +107,20 @@ export class AppComponent implements OnInit, OnDestroy {
   dmpButtonClick(action: string): void {
     this.form_buttons.setButtonMessage(action);
     this.form_buttons.buttonSubject$.next(action);
+  }
+
+  openShareDialog(): void {
+    if (!this.currentDmpId) return;
+    this.dialog.open(PermissionManagerDialogComponent, {
+      data: {
+        record: {
+          id: this.currentDmpId,
+          apiBase: this.configService.getConfig<DMPConfiguration>().PDRDMP
+        },
+        title: 'Share my record'
+      },
+      maxWidth: '95vw'
+    });
   }
 
   // Subscribe to form-change state. Called once from ngOnInit; teardown via destroy$.

--- a/oar-dmp/src/app/app.module.ts
+++ b/oar-dmp/src/app/app.module.ts
@@ -37,7 +37,8 @@ import { FilterPipe } from './resource-options/filter.pipe';
 import { RELEASE } from '../environments/release-info';
 import { environment } from '../environments/environment';
 import { CONFIG_URL, RELEASE_INFO, AuthModule, FrameModule, StaffDirModule, ConfigModule,
-  AuthenticationService, MockAuthenticationService, FooterComponent, HeaderComponent } from 'oarng';
+  AuthenticationService, MockAuthenticationService, FooterComponent, HeaderComponent,
+  GroupsModule, GROUPS_AUTH_TOKEN } from 'oarng';
 
 
 import { SecurityAndPrivacyComponent } from './form-components/security-and-privacy/security-and-privacy.component';
@@ -85,12 +86,22 @@ import { SecurityAndPrivacyComponent } from './form-components/security-and-priv
     MatIconModule,
     
     DmpRoutingModule,
-    NistResourcesModule
+    NistResourcesModule,
+    GroupsModule
   ],
 
   providers: [
     { provide: RELEASE_INFO, useValue: RELEASE },
     { provide: CONFIG_URL, useValue: environment.configUrl },
+    {
+      provide: GROUPS_AUTH_TOKEN,
+      useFactory: (authSvc: AuthenticationService) => {
+        let cachedToken = '';
+        authSvc.getCredentials(true).subscribe(creds => { cachedToken = creds?.token ?? ''; });
+        return () => cachedToken;
+      },
+      deps: [AuthenticationService]
+    },
     // { provide: AuthenticationService, useClass:MockAuthenticationService } // MockAuthenticationService used in dev. Comment out in production
   ],
 

--- a/oar-dmp/src/app/dmp-form/dmp-form.component.spec.ts
+++ b/oar-dmp/src/app/dmp-form/dmp-form.component.spec.ts
@@ -80,7 +80,8 @@ describe('DmpFormComponent', () => {
 
     formChangedServiceMock = {
       disableSaveBtn$: { next: jest.fn() },
-      hasUnsavedChanges$: { next: jest.fn() }
+      hasUnsavedChanges$: { next: jest.fn() },
+      currentDmpId$: { next: jest.fn() }
     };
 
     peopleUpdatesMock = {
@@ -428,6 +429,22 @@ describe('DmpFormComponent', () => {
       component.ngOnDestroy();
       expect(nextSpy).toHaveBeenCalled();
       expect(completeSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('currentDmpId$ propagation', () => {
+    it('should push the route id into FormChangedService on init', () => {
+      activatedRouteMock.snapshot.paramMap.get.mockReturnValue('dmp-999');
+      activatedRouteMock.data = of({ action: 'edit' });
+      fixture.detectChanges();
+      expect(formChangedServiceMock.currentDmpId$.next).toHaveBeenCalledWith('dmp-999');
+    });
+
+    it('should push null into FormChangedService on destroy', () => {
+      activatedRouteMock.data = of({ action: 'new' });
+      fixture.detectChanges();
+      component.ngOnDestroy();
+      expect(formChangedServiceMock.currentDmpId$.next).toHaveBeenCalledWith(null);
     });
   });
 });

--- a/oar-dmp/src/app/dmp-form/dmp-form.component.ts
+++ b/oar-dmp/src/app/dmp-form/dmp-form.component.ts
@@ -190,6 +190,7 @@ export class DmpFormComponent implements OnInit, OnDestroy {
     this.formExportFormatSubscribe();
 
     this.id = this.route.snapshot.paramMap.get('id');
+    this.formChanged.currentDmpId$.next(this.id);
     this.resolveActionFromRoute();
 
     if (this.action === "new") {
@@ -200,6 +201,7 @@ export class DmpFormComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
+    this.formChanged.currentDmpId$.next(null);
     this.destroy$.next();
     this.destroy$.complete();
   }

--- a/oar-dmp/src/app/shared/form-changed.service.ts
+++ b/oar-dmp/src/app/shared/form-changed.service.ts
@@ -1,13 +1,13 @@
 import { Injectable } from '@angular/core';
 //for sending messages between unrelated components
-import { Subject } from 'rxjs';
+import { BehaviorSubject, Subject } from 'rxjs';
 
 @Injectable({
   providedIn: 'root'
 })
 export class FormChangedService {
 
-  constructor() { 
+  constructor() {
     // this.enableSaveButton = false;
   }
 
@@ -16,4 +16,7 @@ export class FormChangedService {
 
   /** true => there are unsaved changes (button shows the "update" style). */
   hasUnsavedChanges$ = new Subject<boolean>();
+
+  /** The ID of the DMP currently open in the editor; null when on /new or no record loaded. */
+  currentDmpId$ = new BehaviorSubject<string | null>(null);
 }

--- a/oar-dmp/src/assets/environment.json
+++ b/oar-dmp/src/assets/environment.json
@@ -6,8 +6,5 @@
   "staffdir": {
     "serviceEndpoint":  "http://localhost:9091/midas/nsd/oar1",
     "requireAuthToken": true
-  },
-  "peopleURL": "http://localhost:9091/midas/nsd/oar1/people/index",
-  "orgURL": "http://localhost:9091/midas/nsd/oar1/orgs/index",
-  "personURL": "http://localhost:9091/midas/nsd/oar1/people/"
+  }
 }

--- a/oar-dmp/src/assets/environment.json
+++ b/oar-dmp/src/assets/environment.json
@@ -6,5 +6,8 @@
   "staffdir": {
     "serviceEndpoint":  "http://localhost:9091/midas/nsd/oar1",
     "requireAuthToken": true
-  }
+  },
+  "peopleURL": "http://localhost:9091/midas/nsd/oar1/people/index",
+  "orgURL": "http://localhost:9091/midas/nsd/oar1/orgs/index",
+  "personURL": "http://localhost:9091/midas/nsd/oar1/people/"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,13 +21,20 @@
             "version": "0.0.1",
             "dependencies": {
                 "@angular/animations": "^18.2.13",
+                "@angular/cdk": "^18.2.13",
                 "@angular/common": "^18.2.13",
                 "@angular/compiler": "^18.2.13",
                 "@angular/core": "^18.2.13",
                 "@angular/forms": "^18.2.13",
+                "@angular/material": "^18.2.13",
                 "@angular/platform-browser": "^18.2.13",
                 "@angular/platform-browser-dynamic": "^18.2.13",
                 "@angular/router": "^18.2.13",
+                "@fortawesome/angular-fontawesome": "^0.15.0",
+                "@fortawesome/fontawesome-svg-core": "^6.6.0",
+                "@fortawesome/free-brands-svg-icons": "^6.6.0",
+                "@fortawesome/free-regular-svg-icons": "^6.6.0",
+                "@fortawesome/free-solid-svg-icons": "^6.6.0",
                 "angular-archwizard": "^6.0.0",
                 "bootstrap": "^5.3.2",
                 "primeflex": "^3.3.1",
@@ -62,6 +69,12 @@
             "peerDependencies": {
                 "@angular/common": "^18.2.13",
                 "@angular/core": "^18.2.13",
+                "@angular/material": "^18.2.13",
+                "@fortawesome/angular-fontawesome": "^0.15.0",
+                "@fortawesome/fontawesome-svg-core": "^6.6.0",
+                "@fortawesome/free-brands-svg-icons": "^6.6.0",
+                "@fortawesome/free-regular-svg-icons": "^6.6.0",
+                "@fortawesome/free-solid-svg-icons": "^6.6.0",
                 "ng-sidebar": "^9.1.1",
                 "primeflex": "^3.3.1",
                 "primeicons": "^7.0.0",
@@ -3524,6 +3537,76 @@
             ],
             "engines": {
                 "node": ">=18"
+            }
+        },
+        "node_modules/@fortawesome/angular-fontawesome": {
+            "version": "0.15.0",
+            "resolved": "https://registry.npmjs.org/@fortawesome/angular-fontawesome/-/angular-fontawesome-0.15.0.tgz",
+            "integrity": "sha512-oxmJDYGNSym5ycFR0LX4ZOPAU+wWmMAznYpkm5DNAtWWkhMLcrZl15eZQmVIEE+qruQ7JiVrg3tpo8bEkFlDgw==",
+            "license": "MIT",
+            "dependencies": {
+                "@fortawesome/fontawesome-svg-core": "^6.5.2",
+                "tslib": "^2.6.2"
+            },
+            "peerDependencies": {
+                "@angular/core": "^18.0.0"
+            }
+        },
+        "node_modules/@fortawesome/fontawesome-common-types": {
+            "version": "6.7.2",
+            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.7.2.tgz",
+            "integrity": "sha512-Zs+YeHUC5fkt7Mg1l6XTniei3k4bwG/yo3iFUtZWd/pMx9g3fdvkSK9E0FOC+++phXOka78uJcYb8JaFkW52Xg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/@fortawesome/fontawesome-svg-core": {
+            "version": "6.7.2",
+            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.7.2.tgz",
+            "integrity": "sha512-yxtOBWDrdi5DD5o1pmVdq3WMCvnobT0LU6R8RyyVXPvFRd2o79/0NCuQoCjNTeZz9EzA9xS3JxNWfv54RIHFEA==",
+            "license": "MIT",
+            "dependencies": {
+                "@fortawesome/fontawesome-common-types": "6.7.2"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/@fortawesome/free-brands-svg-icons": {
+            "version": "6.7.2",
+            "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-6.7.2.tgz",
+            "integrity": "sha512-zu0evbcRTgjKfrr77/2XX+bU+kuGfjm0LbajJHVIgBWNIDzrhpRxiCPNT8DW5AdmSsq7Mcf9D1bH0aSeSUSM+Q==",
+            "license": "(CC-BY-4.0 AND MIT)",
+            "dependencies": {
+                "@fortawesome/fontawesome-common-types": "6.7.2"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/@fortawesome/free-regular-svg-icons": {
+            "version": "6.7.2",
+            "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.7.2.tgz",
+            "integrity": "sha512-7Z/ur0gvCMW8G93dXIQOkQqHo2M5HLhYrRVC0//fakJXxcF1VmMPsxnG6Ee8qEylA8b8Q3peQXWMNZ62lYF28g==",
+            "license": "(CC-BY-4.0 AND MIT)",
+            "dependencies": {
+                "@fortawesome/fontawesome-common-types": "6.7.2"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/@fortawesome/free-solid-svg-icons": {
+            "version": "6.7.2",
+            "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.7.2.tgz",
+            "integrity": "sha512-GsBrnOzU8uj0LECDfD5zomZJIjrPhIlWU82AHwa2s40FKH+kcxQaBvBo3Z4TxyZHIyX8XTDxsyA33/Vx9eFuQA==",
+            "license": "(CC-BY-4.0 AND MIT)",
+            "dependencies": {
+                "@fortawesome/fontawesome-common-types": "6.7.2"
+            },
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/@inquirer/checkbox": {


### PR DESCRIPTION
* Share dialog — a Share action in the editor opens PermissionManagerDialogComponent for the current DMP; the dialog shows a "To manage your groups go to the portal" link driven by the new portalUI config key.

* Configuration — NSD access consolidated under staffdir.serviceEndpoint (with requireAuthToken); flat NSD URL keys removed; portalUI added.


* Lib submodule — points to oar-lib-angular feature/share-my-record.